### PR TITLE
Adding packages.json so this repo can be used with create-project

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,0 +1,16 @@
+{
+  "packages": {
+    "fruition-github": {
+      "dev-master": {
+        "name": "fruition/wingsuit-kickstarter",
+        "source": {
+          "reference": "dev-master",
+          "type": "github",
+          "url": "https://github.com/fruition/wingsuit-kickstarter"
+        },
+        "type": "project",
+        "version": "dev-master"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adding packages.json so this repo can be tested with `composer create-project`.

Note:  The packages.json file added with this MR will need to be removed before opening a PR against the parent repository from which this one was forked.